### PR TITLE
raising exception on bad firmware

### DIFF
--- a/python/library/skywriter.py
+++ b/python/library/skywriter.py
@@ -285,6 +285,12 @@ def handle_firmware_info(data):
 
   print(d_fw_version)
 
+  if d_fw_valid == 0:
+    raise Exception("No valid GestIC Library could be located")
+
+  if d_fw_valid == 0x0A:
+    raise Exception("An invalid GestiIC Library was stored, or the last update failed")
+
 def _do_poll():
   global io_error_count
 


### PR DESCRIPTION
Throws an exception when the firmware info indicates an error, letting the user know what is wrong. Tested it on my busted firmware.