### PR TITLE
Fix polling thread and sensor data interpretation

### DIFF
--- a/library/CHANGELOG.txt
+++ b/library/CHANGELOG.txt
@@ -1,3 +1,8 @@
+0.0.9
+-----
+
+* Fix polling thread and sensor data interpretation
+
 0.0.8
 -----
 
@@ -37,10 +42,7 @@
 
 * Many changes and fixes
 
- 
-
 0.0.1
 -----
 
 * Initial release
-

--- a/library/MANIFEST.in
+++ b/library/MANIFEST.in
@@ -2,4 +2,3 @@ include CHANGELOG.txt
 include LICENSE.txt
 include README.md
 include setup.py
-include skywriter.py

--- a/library/setup.py
+++ b/library/setup.py
@@ -39,7 +39,7 @@ classifiers = ['Development Status :: 5 - Production/Stable',
 
 setup(
     name            = 'skywriter',
-    version         = '0.0.8',
+    version         = '0.0.9',
     author          = 'Philip Howard',
     author_email    = 'phil@pimoroni.com',
     description     = 'Skywriter HAT Driver',

--- a/library/skywriter/__init__.py
+++ b/library/skywriter/__init__.py
@@ -290,13 +290,13 @@ def _handle_firmware_info(data):
         raise Exception("An invalid GestiIC Library was stored, or the last update failed")
 
 
-def _do_poll():
+def _do_poll() -> bool:
     global io_error_count
 
     time.sleep(0.001)
 
     if not _enable_events:
-        return
+        return True
 
     if not GPIO.input(SW_XFER_PIN):
         '''
@@ -313,7 +313,7 @@ def _do_poll():
             io_error_count += 1
             if io_error_count > 10:
                 raise Exception("Skywriter encoutered nore than 10 consecutive I2C IO errors!")
-            return
+            return False
 
         # d_size = data.pop(0)
         # d_flags = data.pop(0)
@@ -333,6 +333,8 @@ def _do_poll():
             pass
 
         GPIO.setup(SW_XFER_PIN, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+
+    return True
 
 
 def _start_poll():

--- a/library/skywriter/__init__.py
+++ b/library/skywriter/__init__.py
@@ -140,7 +140,8 @@ def _handle_sensor_data(data):
     global _lastrotation, rotation
 
     d_configmask = data.pop(0) | data.pop(0) << 8
-    # d_timestamp = data.pop(0)  # 200hz, 8-bit counter, max ~1.25sec
+    # d_timestamp - 200hz, 8-bit counter, max ~1.25sec
+    data.pop(0)
     d_sysinfo = data.pop(0)
 
     # d_dspstatus = data[0:2]
@@ -275,10 +276,14 @@ def _handle_firmware_info(data):
     print('Got firmware info')
 
     d_fw_valid = data.pop(0)
-    # d_hw_rev = data.pop(0) | data.pop(0) << 8
-    # d_param_st = data.pop(0)
-    # d_loader_version = [ data.pop(0), data.pop(0), data.pop(0) ],
-    # d_fw_st = data.pop(0)
+    # d_hw_rev
+    _ = data.pop(0) | data.pop(0) << 8
+    # d_param_st
+    data.pop(0)
+    # d_loader_version
+    _ = [data.pop(0), data.pop(0), data.pop(0)]
+    # d_fw_st
+    data.pop(0)
     d_fw_version = ''.join(map(chr, data))
 
     print(d_fw_version)
@@ -315,9 +320,12 @@ def _do_poll():
                 raise Exception("Skywriter encoutered nore than 10 consecutive I2C IO errors!")
             return
 
-        # d_size = data.pop(0)
-        # d_flags = data.pop(0)
-        # d_seq = data.pop(0)
+        # d_size
+        data.pop(0)
+        # d_flags
+        data.pop(0)
+        # d_seq
+        data.pop(0)
         d_ident = data.pop(0)
 
         if d_ident == 0x91:

--- a/library/skywriter/__init__.py
+++ b/library/skywriter/__init__.py
@@ -139,17 +139,16 @@ class AsyncWorker(StoppableThread):
 def _handle_sensor_data(data):
     global _lastrotation, rotation
 
-    d_configmask = data.pop(0) | data.pop(0) << 8
-    # d_timestamp - 200hz, 8-bit counter, max ~1.25sec
-    data.pop(0)
-    d_sysinfo = data.pop(0)
+    d_configmask = data[0] | data[1] << 8
+    # d_timestamp = data[2] (200hz, 8-bit counter, max ~1.25sec)
+    d_sysinfo = data[3]
 
-    # d_dspstatus = data[0:2]
-    d_gesture = data[2:6]
-    d_touch = data[6:10]
-    d_airwheel = data[10:12]
-    d_xyz = data[12:20]
-    # d_noisepow = data[20:24]
+    # d_dspstatus = data[4:6]
+    d_gesture = data[6:10]
+    d_touch = data[10:14]
+    d_airwheel = data[14:16]
+    d_xyz = data[16:24]
+    # d_noisepow = data[24:28]
 
     if d_configmask & SW_DATA_XYZ and d_sysinfo & 0b0000001:
         # We have xyz info, and it's valid
@@ -275,16 +274,12 @@ def _handle_status_info(data):
 def _handle_firmware_info(data):
     print('Got firmware info')
 
-    d_fw_valid = data.pop(0)
-    # d_hw_rev
-    _ = data.pop(0) | data.pop(0) << 8
-    # d_param_st
-    data.pop(0)
-    # d_loader_version
-    _ = [data.pop(0), data.pop(0), data.pop(0)]
-    # d_fw_st
-    data.pop(0)
-    d_fw_version = ''.join(map(chr, data))
+    d_fw_valid = data[0]
+    # d_hw_rev = data[2] << 8 | data[1]
+    # d_param_st = data[3]
+    # d_loader_version = [data[4], data[5], data[6]]
+    # d_fw_st = data[7]
+    d_fw_version = ''.join(map(chr, data[8:]))
 
     print(d_fw_version)
 
@@ -320,13 +315,10 @@ def _do_poll():
                 raise Exception("Skywriter encoutered nore than 10 consecutive I2C IO errors!")
             return
 
-        # d_size
-        data.pop(0)
-        # d_flags
-        data.pop(0)
-        # d_seq
-        data.pop(0)
-        d_ident = data.pop(0)
+        # d_size = data[0]
+        # d_flags = data[1]
+        # d_seq = data[2]
+        d_ident = data[3]
 
         if d_ident == 0x91:
             _handle_sensor_data(data)

--- a/library/skywriter/__init__.py
+++ b/library/skywriter/__init__.py
@@ -290,7 +290,7 @@ def _handle_firmware_info(data):
         raise Exception("An invalid GestiIC Library was stored, or the last update failed")
 
 
-def _do_poll() -> bool:
+def _do_poll():
     global io_error_count
 
     time.sleep(0.001)

--- a/library/skywriter/__init__.py
+++ b/library/skywriter/__init__.py
@@ -275,9 +275,9 @@ def _handle_firmware_info(data):
     print('Got firmware info')
 
     d_fw_valid = data[0]
-    # d_hw_rev = data[2] << 8 | data[1]
+    # d_hw_rev = data[1] | data[2] << 8
     # d_param_st = data[3]
-    # d_loader_version = [data[4], data[5], data[6]]
+    # d_loader_version = data[4:7]
     # d_fw_st = data[7]
     d_fw_version = ''.join(map(chr, data[8:]))
 

--- a/library/skywriter/__init__.py
+++ b/library/skywriter/__init__.py
@@ -16,7 +16,7 @@ try:
 except ImportError:
     raise ImportError("This library requires the RPi.GPIO module\nInstall with: sudo pip install RPi.GPIO")
 
-__version__ = '0.0.8'
+__version__ = '0.0.9'
 
 SW_ADDR = 0x42
 SW_RESET_PIN = 17


### PR DESCRIPTION
The [latest release](https://github.com/pimoroni/skywriter-hat/releases/tag/v0.0.8) incorrectly interprets data from the Skywriter HAT due to changes to the code in c670aa15647179fc8ebd0891d5bef134baac9435: each commented call to `pop` originally shifted the bytes in `data` to put the next unread byte at the head of the list, but this side effect has not been replicated. Also, `_do_poll` is expected to return a Boolean value to the `AsyncWorker` instance indicating whether to poll the sensor again - no such value is returned, and the default value `None` is falsy, so the poll only occurs once.

This PR addresses the former issue by avoiding the use of `pop` altogether, and ensures that `_do_poll` returns `True` if the polling thread should continue. The version is also bumped to 0.0.9.